### PR TITLE
Add loading skeletons

### DIFF
--- a/frontend/src/components/dashboard/RecordingsList.jsx
+++ b/frontend/src/components/dashboard/RecordingsList.jsx
@@ -72,14 +72,6 @@ export default function RecordingsList({ participantId }) {
 
   const formatDuration = (s) => `${Math.floor(s / 60)}:${Math.floor(s % 60).toString().padStart(2, '0')}`;
 
-  // Simulate loading for 3 seconds
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setLoading(false);
-    }, 60 * 60 * 1000); // 3 seconds
-    return () => clearTimeout(timer);
-  }, []);
-
   if (loading){
     return (
       <div className="w-screen h-screen flex justify-center items-start p-10">


### PR DESCRIPTION
### Add Skeleton Loader to RecordingsList.jsx (Issue #5)
Made changes to file: frontend/src/dashboard/RecordingsList.jsx to change the "Loading recordings..." into actual Loader using the ui/skeleton.jsx 's Skeleton component.

### Related Issue
Closes #5 

### Changes made
Imported and used the Skeleton component from ShadCN UI.
Replaced the "Loading recordings..." loading state with a grid based skeleton loader.